### PR TITLE
libgomp: defined OMPD library-wide functions.

### DIFF
--- a/libgomp/libgompd.h
+++ b/libgomp/libgompd.h
@@ -36,6 +36,6 @@
 
 #define OMPD_VERSION 201811
 
-ompd_callbacks_t* gompd_callbacks;
+extern ompd_callbacks_t gompd_callbacks;
 
 #endif /* LIBGOMPD_H */

--- a/libgomp/libgompd.h
+++ b/libgomp/libgompd.h
@@ -29,9 +29,13 @@
 #ifndef LIBGOMPD_H
 #define LIBGOMPD_H 1
 
+#include "omp-tools.h"
+
 #define ompd_stringify(x) ompd_str2(x)
 #define ompd_str2(x) #x
 
 #define OMPD_VERSION 201811
+
+ompd_callbacks_t* gompd_callbacks;
 
 #endif /* LIBGOMPD_H */

--- a/libgomp/ompd-lib.c
+++ b/libgomp/ompd-lib.c
@@ -28,7 +28,9 @@
 
 #include "omp-tools.h"
 #include "libgompd.h"
-#include <stdlib.h>
+
+ompd_callbacks_t gompd_callbacks;
+static int ompd_initialized = 0;
 
 ompd_rc_t
 ompd_get_api_version (ompd_word_t *version)
@@ -48,16 +50,13 @@ ompd_get_version_string (const char **string)
 ompd_rc_t
 ompd_initialize (ompd_word_t api_version, const ompd_callbacks_t *callbacks)
 {
-  static int ompd_initialized = 0;
-
   if (!callbacks)
     return ompd_rc_bad_input;
 
   if (ompd_initialized)
     return ompd_rc_error;
 
-  gompd_callbacks = malloc(sizeof(ompd_callbacks_t));
-  *gompd_callbacks  = *callbacks;
+  gompd_callbacks = *callbacks;
 
   (void) api_version;
 
@@ -67,8 +66,8 @@ ompd_initialize (ompd_word_t api_version, const ompd_callbacks_t *callbacks)
 }
 
 ompd_rc_t
-ompd_finalize(void)
+ompd_finalize (void)
 {
-  free (gompd_callbacks);
+  ompd_initialized = 0;
   return ompd_rc_ok;
 }

--- a/libgomp/ompd-lib.c
+++ b/libgomp/ompd-lib.c
@@ -28,6 +28,7 @@
 
 #include "omp-tools.h"
 #include "libgompd.h"
+#include <stdlib.h>
 
 ompd_rc_t
 ompd_get_api_version (ompd_word_t *version)
@@ -49,13 +50,25 @@ ompd_initialize (ompd_word_t api_version, const ompd_callbacks_t *callbacks)
 {
   static int ompd_initialized = 0;
 
+  if (!callbacks)
+    return ompd_rc_bad_input;
+
   if (ompd_initialized)
     return ompd_rc_error;
 
+  gompd_callbacks = malloc(sizeof(ompd_callbacks_t));
+  *gompd_callbacks  = *callbacks;
+
   (void) api_version;
-  (void) callbacks;
 
   ompd_initialized = 1;
 
+  return ompd_rc_ok;
+}
+
+ompd_rc_t
+ompd_finalize(void)
+{
+  free (gompd_callbacks);
   return ompd_rc_ok;
 }


### PR DESCRIPTION
This patch provides an initial set of definition for the rest of library-wide OMPD functions.

It addresses all feedbacks.

2020-07-01  Tony Sim  <y2s1982@gmail.com>

libgomp/ChangeLog:

        * libgompd.h: Include omp-tools.h.
        (gompd_callbacks): New extern declaration.
        * ompd-lib.c (gompd_callbacks): New declaration.
        (ompd_initialized): New declaration.
        (ompd_initialize): Checks callbacks and assigns it to gompd_callbacks.
        (ompd_finalize): Add new function.
